### PR TITLE
Write fullpath (or at least given path) in output po file

### DIFF
--- a/XGetText.Xaml/XGetText-Xaml.Tests.ps1
+++ b/XGetText.Xaml/XGetText-Xaml.Tests.ps1
@@ -47,7 +47,7 @@ Describe "XGetText-Xaml" {
     }
 
     It "Annotates msgid with filename and line number" {
-        XGetText-Xaml TestDrive:\TestFile.xaml -k Gettext -o - | Should -Match ([regex]::Escape("#: TestFile.xaml:8" + [System.Environment]::NewLine + "msgid ""NGettext.WPF Example""")) 
+        XGetText-Xaml TestDrive:\TestFile.xaml -k Gettext -o - | Should -Match ([regex]::Escape("#: TestDrive:\TestFile.xaml:8" + [System.Environment]::NewLine + "msgid ""NGettext.WPF Example""")) 
     }
 
 	It "Annotates msgid with msgctxt" {
@@ -56,7 +56,7 @@ Describe "XGetText-Xaml" {
     }
 
     It "Joins matching msgids" {
-        XGetText-Xaml TestDrive:\TestFile.xaml -k Gettext -o - | Should -Match ([regex]::Escape("#: TestFile.xaml:26" + [System.Environment]::NewLine + "#: TestFile.xaml:27" + [System.Environment]::NewLine +"msgid ""Danish"""))
+        XGetText-Xaml TestDrive:\TestFile.xaml -k Gettext -o - | Should -Match ([regex]::Escape("#: TestDrive:\TestFile.xaml:26" + [System.Environment]::NewLine + "#: TestDrive:\TestFile.xaml:27" + [System.Environment]::NewLine +"msgid ""Danish"""))
     }
 
     It "Does not ignore casing of msgids when joining" {
@@ -71,7 +71,7 @@ Describe "XGetText-Xaml" {
     }
 
     It "Quotes are optional" {
-        XGetText-Xaml TestDrive:\TestFile.xaml -k Gettext -o - | Should -Match ([regex]::Escape("#: TestFile.xaml:28" + [System.Environment]::NewLine + "#: TestFile.xaml:29" + [System.Environment]::NewLine +"msgid ""Quotes are optional"""))
+        XGetText-Xaml TestDrive:\TestFile.xaml -k Gettext -o - | Should -Match ([regex]::Escape("#: TestDrive:\TestFile.xaml:28" + [System.Environment]::NewLine + "#: TestDrive:\TestFile.xaml:29" + [System.Environment]::NewLine +"msgid ""Quotes are optional"""))
     }
 
     It "Supports escaped single-quotes" {

--- a/XGetText.Xaml/XGetText-Xaml.ps1
+++ b/XGetText.Xaml/XGetText-Xaml.ps1
@@ -20,9 +20,10 @@
 	
 	ForEach ($keyword in $Keywords)
 	{
-		$sourceFiles | ForEach-Object {
-			Select-String $_ -Pattern $("{[a-z]?[a-z0-9]*:"+$keyword+ " (([^}{]|{[^}]*})*)}") -AllMatches | ForEach-Object {
-				$filename = $_.Filename
+		ForEach ($sourceFile in $sourceFiles)
+		{
+			Select-String $sourceFile -Pattern $("{[a-z]?[a-z0-9]*:"+$keyword+ " (([^}{]|{[^}]*})*)}") -AllMatches | ForEach-Object {
+				$filename = $sourceFile
 				$lineNumber = $_.LineNumber
 				$_.Matches | ForEach-Object {
 					$msgid = $_.Groups[1].ToString()


### PR DESCRIPTION
In order for PoEdit to show reference in its viewer, it needs the path to the file.

This pull request passes the path information we have about the source file to the po file.